### PR TITLE
Add base configuration and extensive readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Cache objects
+packer_cache/
+
+# Crash log
+crash.log
+
+# For built boxes
+*.box
+
+# For MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# backpack
+# `backpack`
+This repository contains the packer configuration to build a base box for use with our [box](https://github.com/uw-midsun/box).
+
+# ⚠️ NOTICE ⚠️
+This repository is currently **experimental**. It hasn't been tested with utilities for working with firmware onsite.
+
+## What is packer?
+[Packer](https://www.packer.io/) is a program that takes in some configuration and outputs a machine image. This machine image can be loaded into virtualbox with [vagrant](https://www.vagrantup.com/). This toolchain of packer -> vagrant -> virtualbox allows us to provide a standardized development environment, regardless of host OS.
+
+It works in three steps:
+1. Execute builders. This is basically the initial ubuntu configuration, which is defined in the `builders` section of `backpack.json` and `http/preseed.cfg`. You'll (hopefully) never need to touch these.
+2. Run provisioners. These are defined in the `provisioners` section of `backpack.json`. There are a number of provisioning tools you might see in industry or in job descriptions like [chef](https://www.chef.io/), [ansible](https://www.ansible.com/), and [puppet](https://puppet.com/). However, we opt for simple shell scripts to do the provisioning because they're easier to understand and update without learning new tools. These scripts live in `scripts`, and are probably the only things you'll need to touch in this repo.
+3. Run post-processors. This is the `post-processors` section of `backpack.json`, and is what outputs the final vagrant-compatible image.
+
+## Philosophy
+Packer configuration is pretty complex already, so this repo is designed to make it as easy as possible to add to the "backpack". Keeping things in here makes for a more smooth onboarding and setup process for new team members. If adding extra functionality, make sure to add comments and keep things neat for future generations.
+
+## Dependencies
+In order to work with packer, you'll need:
+- ruby
+- packer
+- virtualbox
+However, in order to properly test and release, it's highly recommended you have the uwmidsun [box](https://github.com/uw-midsun/box) set up in order to properly test your changes.
+
+## Adding functionality
+First, set up a brand new [box](https://github.com/uw-midsun/box) to test your changes with. Run your installation commands as you would, but with `sudo`. As an example, if you wanted to add `foobar`:
+```
+sudo apt-get -y install foobar
+```
+After you've made sure `foobar` is working correctly, add the same commands to the appropriate setup script without the `sudo`, with a comment:
+```
+...
+#Install foobar
+apt-get -y install foobar
+...
+```
+If you're adding significant steps, consider adding an additional setup script by adding its name to the `scripts` section of `backpack.json`, then creating the new script in the `scripts` directory.
+
+Once you're happy with your changes, pack the new box with:
+```
+packer build backpack.json
+```
+This will take a really long time, potentially up to 20 minutes. The process may appear to be stuck at:
+```
+==> virtualbox-iso: Waiting for SSH to become available...
+```
+This is normal. Give it at least 10 minutes just at this step before deciding the run's a failure.
+
+On success, something along the lines of the following should appear:
+```
+==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider
+    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/packer-ubuntu-18.04-amd64-disk001.vmdk
+    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/packer-ubuntu-18.04-amd64.ovf
+    virtualbox-iso (vagrant): Renaming the OVF to box.ovf...
+    virtualbox-iso (vagrant): Compressing: Vagrantfile
+    virtualbox-iso (vagrant): Compressing: box.ovf
+    virtualbox-iso (vagrant): Compressing: metadata.json
+    virtualbox-iso (vagrant): Compressing: packer-ubuntu-18.04-amd64-disk001.vmdk
+Build 'virtualbox-iso' finished after 15 minutes 13 seconds.
+```
+This should be accompanied by the creation of the file `backpack.box` in this directory. Release this as a new version [here](https://github.com/uw-midsun/backpack/releases/new), bumping the minor or major version number as appropriate. Finally, open a PR to bump the backpack version in the [box](https://github.com/uw-midsun/box) repo by changing the line that looks something like:
+```
+config.vm.box_url = "https://github.com/uw-midsun/box/releases/download/v1.1.0/backpack.box"
+```

--- a/backpack.json
+++ b/backpack.json
@@ -1,0 +1,84 @@
+{
+    "builders": [
+        {
+            "type": "virtualbox-iso",
+            "boot_command": [
+                "<esc><wait>",
+                "<esc><wait>",
+                "<enter><wait>",
+                "/install/vmlinuz<wait>",
+                " auto<wait>",
+                " console-setup/ask_detect=false<wait>",
+                " console-setup/layoutcode=us<wait>",
+                " console-setup/modelcode=pc105<wait>",
+                " debconf/frontend=noninteractive<wait>",
+                " debian-installer=en_US<wait>",
+                " fb=false<wait>",
+                " initrd=/install/initrd.gz<wait>",
+                " kbd-chooser/method=us<wait>",
+                " keyboard-configuration/layout=USA<wait>",
+                " keyboard-configuration/variant=USA<wait>",
+                " locale=en_US<wait>",
+                " netcfg/get_domain=vm<wait>",
+                " netcfg/get_hostname=vagrant<wait>",
+                " grub-installer/bootdev=/dev/sda<wait>",
+                " noapic<wait>",
+                " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+                " -- <wait>",
+                "<enter><wait>"
+            ],
+            "boot_wait": "10s",
+            "disk_size": 40000,
+            "guest_os_type": "Ubuntu_64",
+            "headless": true,
+            "http_directory": "http",
+            "iso_urls": [
+                "ubuntu-18.04.5-server-amd64.iso",
+                "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/ubuntu-18.04.5-server-amd64.iso"
+            ],
+            "iso_checksum": "sha256:8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "ssh_port": 22,
+            "ssh_wait_timeout": "10000s",
+            "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+            "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+            "virtualbox_version_file": ".vbox_version",
+            "vm_name": "packer-ubuntu-18.04-amd64",
+            "vboxmanage": [
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--memory",
+                    "1024"
+                ],
+                [
+                    "modifyvm",
+                    "{{.Name}}",
+                    "--cpus",
+                    "1"
+                ]
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+            "expect_disconnect": true,
+            "type": "shell",
+            "scripts": [
+                "scripts/system_setup.sh",
+                "scripts/firmware_setup.sh",
+                "scripts/other_setup.sh",
+                "scripts/cleanup.sh"
+            ]
+        }
+    ],
+    "post-processors": [
+        {
+            "type": "vagrant",
+            "compression_level": "8",
+            "output": "backpack.box"
+        }
+    ]
+}

--- a/http/preseed.cfg
+++ b/http/preseed.cfg
@@ -1,0 +1,40 @@
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i pkgsel/include string openssh-server ssh
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layoutcode string us
+d-i keyboard-configuration/modelcode string pc105
+d-i debian-installer/locale string en_US.UTF-8
+
+# Create vagrant user account.
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i passwd/user-default-groups vagrant sudo
+d-i passwd/user-uid string 900

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -eu
+# source: https://github.com/heizo/packer-ubuntu-18.04/blob/master/script/cleanup.sh
+
+SSH_USER=${SSH_USERNAME:-vagrant}
+
+echo "==> Cleaning up tmp"
+rm -rf /tmp/*
+
+# Cleanup apt cache
+apt-get -y autoremove --purge
+apt-get -y clean
+
+echo "==> Installed packages"
+dpkg --get-selections | grep -v deinstall
+
+# Remove Bash history
+unset HISTFILE
+rm -f /root/.bash_history
+rm -f /home/${SSH_USER}/.bash_history
+
+echo "==> Clearing machine-id"
+truncate --size=0 /etc/machine-id
+
+echo "==> Clearing log files"
+find /var/log -type f -exec truncate --size=0 {} \;
+
+echo '==> Clear out swap and disable until reboot'
+set +e
+swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
+case "$?" in
+    2|0) ;;
+    *) exit 1 ;;
+esac
+set -e
+if [ "x${swapuuid}" != "x" ]; then
+    # Whiteout the swap partition to reduce box size
+    # Swap is disabled till reboot
+    swappart=$(readlink -f /dev/disk/by-uuid/$swapuuid)
+    /sbin/swapoff "${swappart}"
+    dd if=/dev/zero of="${swappart}" bs=1M || echo "dd exit code $? is suppressed"
+    /sbin/mkswap -U "${swapuuid}" "${swappart}"
+fi
+
+# Zero out the free space to save space in the final image
+if [ -d /boot/efi ]; then
+    dd if=/dev/zero of=/boot/efi/EMPTY bs=1M || echo "dd exit code $? is suppressed"
+    rm -f /boot/efi/EMPTY
+fi
+dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed"
+rm -f /EMPTY
+sync
+
+echo "==> Disk usage after cleanup"
+df -h

--- a/scripts/firmware_setup.sh
+++ b/scripts/firmware_setup.sh
@@ -1,0 +1,32 @@
+# Install clang and gcc
+apt-get -y install gcc-6
+apt-get -y install clang-5.0
+apt-get -y install clang-format-5.0
+ln -sf $(which gcc-6) /usr/bin/gcc
+ln -sf $(which clang-5.0) /usr/bin/clang
+ln -sf $(which clang-format-5.0) /usr/bin/clang-format
+
+# Install arm gcc
+wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O arm-gcc.tar.bz2
+tar xfj arm-gcc.tar.bz2 -C /usr/local
+echo 'PATH=$PATH:/usr/local/gcc-arm-none-eabi-6-2017-q2-update/bin' >> /etc/profile
+rm arm-gcc.tar.bz2
+
+# Install other toolchain pieces
+apt-get -y install minicom
+apt-get -y install openocd
+
+# Install protobuf-c
+apt-get -y install autoconf
+apt-get -y install libtool
+apt-get -y install pkg-config
+apt-get -y install libprotoc-dev
+git clone https://github.com/protobuf-c/protobuf-c
+cd protobuf-c
+./autogen.sh
+./configure
+make
+make install
+ldconfig
+cd /home/vagrant
+rm -rf protobuf-c

--- a/scripts/other_setup.sh
+++ b/scripts/other_setup.sh
@@ -1,0 +1,1 @@
+echo "Put other setup steps in this script"

--- a/scripts/system_setup.sh
+++ b/scripts/system_setup.sh
@@ -1,0 +1,55 @@
+# Configure sudoers
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers;
+sed -i -e 's/%sudo\s*ALL=(ALL:ALL) ALL/%sudo\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers;
+
+# Add public key to enable ssh without password
+pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
+mkdir -p /home/vagrant/.ssh
+wget --no-check-certificate "$pubkey_url" -O /home/vagrant/.ssh/authorized_keys
+chmod 700 /home/vagrant/.ssh
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# Install packages required for building guest additions
+apt-get -y update
+apt-get -y install build-essential linux-headers-generic perl
+apt-get -y install nfs-common dkms
+
+# Configure guest additions to enable shared folder
+VBOX_VER=$(cat /home/vagrant/.vbox_version)
+mount -o loop /home/vagrant/VBoxGuestAdditions_$VBOX_VER.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run || echo "suppressing $? from guest additions"
+umount /mnt
+rm -f /home/vagrant/*.iso
+rm /home/vagrant/.vbox_version
+
+# Install general tools
+apt-get -y install tmux git vim curl
+
+# Install python tooling
+apt-get -y install python3-pip
+apt-get -y install pylint
+apt-get -y install python-autopep8
+apt-get -y install virtualenv
+
+# Install tooling for CAN
+apt-get -y install can-utils
+python3 -m pip install python-can
+python3 -m pip install cantools
+
+# Install go
+wget https://golang.org/dl/go1.16.2.linux-amd64.tar.gz -O go-zip.tar.gz
+tar -xzf go-zip.tar.gz -C /usr/local
+echo 'PATH=$PATH:/usr/local/go/bin' >> /etc/profile
+echo 'GOPATH=/home/vagrant/go' >> /home/vagrant/.bashrc
+rm go*.tar.gz
+
+# Install ruby
+apt-get -y install ruby
+
+# Install protobuf things
+apt-get -y install software-properties-common
+add-apt-repository -y ppa:maarten-fonville/protobuf
+apt-get -y install protobuf-compiler
+python3 -m pip install protobuf
+apt-get -y install golang-goprotobuf-dev


### PR DESCRIPTION
The old uw-midsun/packer repository is pretty bulky and unwieldy, and we aren't able to upload new versions of the box to the vagrant cloud because we've lost the credentials. The plan for this repo is to simply release boxes via github releases, and pull them directly from github in the `box` repo. This should provide a much easier and maintainable flow for releasing new features to the box.

Probably only necessary to check through the readme. I'm not gonna change any of the actual configuration before merging this since I've already released a version with this configuration.